### PR TITLE
Update dependencies.

### DIFF
--- a/OpenTK.WinForms.InputTest/OpenTK.WinForms.InputTest.csproj
+++ b/OpenTK.WinForms.InputTest/OpenTK.WinForms.InputTest.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.4.0" />
+    <PackageReference Include="OpenTK" Version="4.6.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenTK.WinForms.TestForm/OpenTK.WinForms.TestForm.csproj
+++ b/OpenTK.WinForms.TestForm/OpenTK.WinForms.TestForm.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.4.0" />
+    <PackageReference Include="OpenTK" Version="4.6.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenTK.WinForms/OpenTK.WinForms.csproj
+++ b/OpenTK.WinForms/OpenTK.WinForms.csproj
@@ -21,7 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.4.0" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.6.4" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.6.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes are documented in this file.
 
+## 4.0.0-pre.6
+- _August 27, 2021_
+- Update dependencies to OpenTK 4.6.4 packages.
+
 ## 4.0.0-pre.5
 - _March 4, 2021_
 - Add `Context` property for better backward compatibility with GLControl 3.x.


### PR DESCRIPTION
Updates to the latest stable 4.6.4 dependencies and only include the nugets that are needed. This will remove unnecessary parts from the winforms glcontrol package, like the Compute, Input and OpenAL namespaces.